### PR TITLE
Jczaja/xpu tests

### DIFF
--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -25,3 +25,15 @@ def test_ensure_gpu_ext(monkeypatch):
             ensure_gpu_ext()
 
         assert "GPU extensions could not be imported" in str(excinfo.value)
+
+def test_ensure_xpu_ext(monkeypatch):
+    from mpi4jax._src import xla_bridge
+    from mpi4jax._src.decorators import ensure_xpu_ext
+
+    with monkeypatch.context() as m:
+        m.setattr(xla_bridge, "HAS_XPU_EXT", False)
+
+        with pytest.raises(ImportError) as excinfo:
+            ensure_xpu_ext()
+
+        assert "XPU extensions could not be imported" in str(excinfo.value)

--- a/tests/test_has_sycl.py
+++ b/tests/test_has_sycl.py
@@ -1,0 +1,4 @@
+def test_flush():
+    from mpi4jax import has_sycl_support
+
+    assert isinstance(has_sycl_support(), bool)


### PR DESCRIPTION
Added sycl specific tests. Currently allreduce (run on XPU) + sycl specific tests are working. Other tests are failing due to lack of sycl implementation for them


tests/test_decorators.py ...                                             [  2%]
tests/test_examples.py F                                                 [  3%]
tests/test_flush.py .                                                    [  3%]
tests/test_has_cuda.py .                                                 [  4%]
tests/test_has_sycl.py .                                                 [  5%]
tests/test_jax_compat.py .......                                         [ 11%]
tests/test_validation.py ....                                            [ 14%]
tests/collective_ops/test_allgather.py FFFF                              [ 17%]
tests/collective_ops/test_allreduce.py .................                 [ 30%]
tests/collective_ops/test_allreduce_matvec.py ........................   [ 50%]
tests/collective_ops/test_alltoall.py FF.F                               [ 53%]
tests/collective_ops/test_barrier.py F                                   [ 53%]
tests/collective_ops/test_bcast.py FFFF                                  [ 57%]
tests/collective_ops/test_common.py FF..                                 [ 60%]
tests/collective_ops/test_gather.py FFFF                                 [ 63%]
tests/collective_ops/test_reduce.py FFFF                                 [ 66%]
tests/collective_ops/test_scan.py FFFF                                   [ 69%]
tests/collective_ops/test_scatter.py FF.                                 [ 72%]
tests/collective_ops/test_send_and_recv.py sssssss                       [ 77%]
tests/collective_ops/test_sendrecv.py sssssssssss                        [ 86%]
tests/experimental/test_notoken.py FFssFFFFFFFFFFsss                     [100%]
