### PR TITLE
Added XPU support to Reduce

### DIFF
--- a/mpi4jax/_src/xla_bridge/mpi_xla_bridge_xpu.pyx
+++ b/mpi4jax/_src/xla_bridge/mpi_xla_bridge_xpu.pyx
@@ -622,7 +622,8 @@ cdef void mpi_reduce_xpu(void* stream, void** buffers,
 
         if rank == root:
 #            # copy back to device
-            checked_sycl_memcpy(xqueue, out_data, out_buf , count, comm)
+            with gil:
+                checked_sycl_memcpy(xqueue, out_data, out_buf , count, comm)
 
         free(in_buf)
         free(out_buf)

--- a/mpi4jax/_src/xla_bridge/mpi_xla_bridge_xpu.pyx
+++ b/mpi4jax/_src/xla_bridge/mpi_xla_bridge_xpu.pyx
@@ -599,8 +599,9 @@ cdef void mpi_reduce_xpu(void* stream, void** buffers,
     cdef MPI_Comm comm = desc.comm
     cdef MPI_Datatype dtype = desc.dtype
 
-# TODO: uncomment
-#    checked_cuda_stream_synchronize(stream, comm)
+    cdef queue* xqueue = <queue*>stream
+    with gil:
+        checked_sycl_queue_wait(xqueue, comm) 
 
     if COPY_TO_HOST:
         # copy memory to host
@@ -610,8 +611,8 @@ cdef void mpi_reduce_xpu(void* stream, void** buffers,
         count = dtype_size * nitems
         in_buf = checked_malloc(count, comm)
         out_buf = checked_malloc(count, comm)
-# TODO: uncomment
-#        checked_cuda_memcpy(in_buf, data, count, cudaMemcpyDeviceToHost, comm)
+        with gil:
+            checked_sycl_memcpy(xqueue, in_buf, data , count, comm)
 
     mpi_xla_bridge.mpi_reduce(in_buf, out_buf, nitems, dtype, op, root, comm)
 
@@ -619,10 +620,9 @@ cdef void mpi_reduce_xpu(void* stream, void** buffers,
         ierr = MPI_Comm_rank(comm, &rank)
         mpi_xla_bridge.abort_on_error(ierr, comm, u"Comm_rank")
 
-# TODO: uncomment
-#        if rank == root:
+        if rank == root:
 #            # copy back to device
-#            checked_cuda_memcpy(out_data, out_buf, count, cudaMemcpyHostToDevice, comm)
+            checked_sycl_memcpy(xqueue, out_data, out_buf , count, comm)
 
         free(in_buf)
         free(out_buf)

--- a/mpi4jax/experimental/notoken/collective_ops/reduce.py
+++ b/mpi4jax/experimental/notoken/collective_ops/reduce.py
@@ -182,67 +182,6 @@ def mpi_reduce_xla_encode_gpu(ctx, x, op, root, comm):
 
     return results
 
-@translation_rule_xpu
-def mpi_reduce_xla_encode_xpu(ctx, x, op, root, comm):
-    from mpi4jax._src.xla_bridge.mpi_xla_bridge_gpu import build_reduce_descriptor
-
-    op = unpack_hashable(op)
-    comm = unpack_hashable(comm)
-
-    x_aval, *_ = ctx.avals_in
-    x_nptype = x_aval.dtype
-
-    x_type = ir.RankedTensorType(x.type)
-    dtype = x_type.element_type
-    dims = x_type.shape
-
-    # compute total number of elements in array
-    nitems = _np.prod(dims, dtype=int)
-
-    dtype_handle = to_dtype_handle(x_nptype)
-
-    # output is only used on root, so prevent memory allocation
-    rank = comm.Get_rank()
-
-    if rank != root:
-        dims = (0,)
-
-    out_types = [
-        ir.RankedTensorType.get(dims, dtype),
-        *token_type(),
-    ]
-
-    token = ctx.tokens_in.get(ordered_effect)[0]
-
-    operands = (
-        x,
-        token,
-    )
-
-    descriptor = build_reduce_descriptor(
-        nitems,
-        to_mpi_handle(op),
-        root,
-        to_mpi_handle(comm),
-        dtype_handle,
-    )
-
-    result_obj = custom_call(
-        b"mpi_reduce",
-        result_types=out_types,
-        operands=operands,
-        operand_layouts=get_default_layouts(operands),
-        result_layouts=get_default_layouts(out_types),
-        has_side_effect=True,
-        backend_config=descriptor,
-    )
-
-    results = list(result_obj.results)
-    token = results.pop(-1)
-    ctx.set_tokens_out(mlir.TokenSet({ordered_effect: (token,)}))
-
-    return results
-
 # This function evaluates only the shapes during AST construction
 def mpi_reduce_abstract_eval(xs, op, root, comm):
     comm = unpack_hashable(comm)

--- a/mpi4jax/experimental/notoken/collective_ops/reduce.py
+++ b/mpi4jax/experimental/notoken/collective_ops/reduce.py
@@ -182,6 +182,66 @@ def mpi_reduce_xla_encode_gpu(ctx, x, op, root, comm):
 
     return results
 
+@translation_rule_xpu
+def mpi_reduce_xla_encode_xpu(ctx, x, op, root, comm):
+    from mpi4jax._src.xla_bridge.mpi_xla_bridge_gpu import build_reduce_descriptor
+
+    op = unpack_hashable(op)
+    comm = unpack_hashable(comm)
+
+    x_aval, *_ = ctx.avals_in
+    x_nptype = x_aval.dtype
+
+    x_type = ir.RankedTensorType(x.type)
+    dtype = x_type.element_type
+    dims = x_type.shape
+
+    # compute total number of elements in array
+    nitems = _np.prod(dims, dtype=int)
+
+    dtype_handle = to_dtype_handle(x_nptype)
+
+    # output is only used on root, so prevent memory allocation
+    rank = comm.Get_rank()
+
+    if rank != root:
+        dims = (0,)
+
+    out_types = [
+        ir.RankedTensorType.get(dims, dtype),
+        *token_type(),
+    ]
+
+    token = ctx.tokens_in.get(ordered_effect)[0]
+
+    operands = (
+        x,
+        token,
+    )
+
+    descriptor = build_reduce_descriptor(
+        nitems,
+        to_mpi_handle(op),
+        root,
+        to_mpi_handle(comm),
+        dtype_handle,
+    )
+
+    result_obj = custom_call(
+        b"mpi_reduce",
+        result_types=out_types,
+        operands=operands,
+        operand_layouts=get_default_layouts(operands),
+        result_layouts=get_default_layouts(out_types),
+        has_side_effect=True,
+        backend_config=descriptor,
+    )
+
+    results = list(result_obj.results)
+    token = results.pop(-1)
+    ctx.set_tokens_out(mlir.TokenSet({ordered_effect: (token,)}))
+
+    return results
 
 # This function evaluates only the shapes during AST construction
 def mpi_reduce_abstract_eval(xs, op, root, comm):


### PR DESCRIPTION
This PR is extending mpi4jax Reduce to be abel to run on XPU. Unit tests (test_reduce.py) start to pass after this changes.