### PR TITLE
- XPU support to allgather added

### DIFF
--- a/mpi4jax/_src/collective_ops/allgather.py
+++ b/mpi4jax/_src/collective_ops/allgather.py
@@ -129,8 +129,52 @@ def mpi_allgather_xla_encode_cpu(ctx, sendbuf, token, comm):
 
 @translation_rule_xpu
 def mpi_allgather_xla_encode_xpu(ctx, sendbuf, token, comm):
-    print("XPU ALLGATHER not implemented!")
-    exit(-1)
+    from ..xla_bridge.mpi_xla_bridge_xpu import build_allgather_descriptor
+
+    comm = unpack_hashable(comm)
+
+    sendbuf_aval, *_ = ctx.avals_in
+    send_nptype = sendbuf_aval.dtype
+
+    send_type = ir.RankedTensorType(sendbuf.type)
+    send_dtype = send_type.element_type
+    send_dims = send_type.shape
+
+    # compute total number of elements in send array
+    send_nitems = _np.prod(send_dims, dtype=int)
+    send_dtype_handle = to_dtype_handle(send_nptype)
+
+    size = comm.Get_size()
+    out_shape = (size, *send_dims)
+
+    out_types = [
+        ir.RankedTensorType.get(out_shape, send_dtype),
+        *token_type(),
+    ]
+
+    descriptor = build_allgather_descriptor(
+        send_nitems,
+        send_dtype_handle,
+        # we only support matching input and output arrays
+        send_nitems,
+        send_dtype_handle,
+        #
+        to_mpi_handle(comm),
+    )
+
+    operands = (sendbuf, token)
+
+    return custom_call(
+        b"mpi_allgather",
+        result_types=out_types,
+        operands=operands,
+        # layout matters here, because the first axis is special
+        operand_layouts=get_default_layouts(operands, order="c"),
+        result_layouts=get_default_layouts(out_types, order="c"),
+        backend_config=descriptor,
+        has_side_effect=True,
+    ).results
+
 
 @translation_rule_gpu
 def mpi_allgather_xla_encode_gpu(ctx, sendbuf, token, comm):

--- a/mpi4jax/_src/xla_bridge/mpi_xla_bridge_xpu.pyx
+++ b/mpi4jax/_src/xla_bridge/mpi_xla_bridge_xpu.pyx
@@ -124,8 +124,9 @@ cdef void mpi_allgather_xpu(void* stream, void** buffers,
     cdef MPI_Datatype recvtype = desc.recvtype
     cdef MPI_Comm comm = desc.comm
 
-# TODO: uncomment
-#    checked_cuda_stream_synchronize(stream, comm)
+    cdef queue* xqueue = <queue*>stream
+    with gil:
+        checked_sycl_queue_wait(xqueue, comm) 
 
     if COPY_TO_HOST:
         # copy memory to host
@@ -145,8 +146,8 @@ cdef void mpi_allgather_xpu(void* stream, void** buffers,
         recvbytes = recvtype_size * recvcount * comm_size
         out_buf = checked_malloc(recvbytes, comm)
 
-# TODO: uncomment
-#        checked_cuda_memcpy(in_buf, data, sendbytes, cudaMemcpyDeviceToHost, comm)
+        with gil:
+            checked_sycl_memcpy(xqueue, in_buf, data , sendbytes, comm)
 
     mpi_xla_bridge.mpi_allgather(
         in_buf, sendcount, sendtype,
@@ -156,8 +157,8 @@ cdef void mpi_allgather_xpu(void* stream, void** buffers,
 
     if COPY_TO_HOST:
         # copy back to device
-# TODO: uncomment
-#        checked_cuda_memcpy(out_data, out_buf, recvbytes, cudaMemcpyHostToDevice, comm)
+        with gil:
+            checked_sycl_memcpy(xqueue, out_data, out_buf , recvbytes, comm)
         free(in_buf)
         free(out_buf)
 


### PR DESCRIPTION
This PR is adding XPU support to allgather op in mpi4jax

UT passrate with this PR:
============ 29 failed, 74 passed, 23 skipped, 2 warnings in 45.21s ============
