### PR TITLE
added XPU support to scatter op

### DIFF
--- a/mpi4jax/_src/collective_ops/scatter.py
+++ b/mpi4jax/_src/collective_ops/scatter.py
@@ -150,8 +150,55 @@ def mpi_scatter_xla_encode_cpu(ctx, x, token, root, comm):
 
 @translation_rule_xpu
 def mpi_scatter_xla_encode_xpu(ctx, x, token, root, comm):
-    print("XPU SCATTER not implemented!")
-    exit(-1)
+    from ..xla_bridge.mpi_xla_bridge_gpu import build_scatter_descriptor
+
+    comm = unpack_hashable(comm)
+
+    x_aval, *_ = ctx.avals_in
+    x_nptype = x_aval.dtype
+
+    x_type = ir.RankedTensorType(x.type)
+    dtype = x_type.element_type
+    dims = x_type.shape
+
+    rank = comm.Get_rank()
+    if rank == root:
+        dims = dims[1:]
+
+    # compute total number of elements in array
+    nitems = _np.prod(dims, dtype=int)
+    dtype_handle = to_dtype_handle(x_nptype)
+
+    out_types = [
+        ir.RankedTensorType.get(dims, dtype),
+        *token_type(),
+    ]
+
+    operands = (
+        x,
+        token,
+    )
+
+    descriptor = build_scatter_descriptor(
+        nitems,
+        dtype_handle,
+        # we only support matching input and output arrays
+        nitems,
+        dtype_handle,
+        #
+        root,
+        to_mpi_handle(comm),
+    )
+
+    return custom_call(
+        b"mpi_scatter",
+        result_types=out_types,
+        operands=operands,
+        operand_layouts=get_default_layouts(operands),
+        result_layouts=get_default_layouts(out_types),
+        has_side_effect=True,
+        backend_config=descriptor,
+    ).results
 
 @translation_rule_gpu
 def mpi_scatter_xla_encode_gpu(ctx, x, token, root, comm):

--- a/mpi4jax/_src/collective_ops/scatter.py
+++ b/mpi4jax/_src/collective_ops/scatter.py
@@ -150,7 +150,7 @@ def mpi_scatter_xla_encode_cpu(ctx, x, token, root, comm):
 
 @translation_rule_xpu
 def mpi_scatter_xla_encode_xpu(ctx, x, token, root, comm):
-    from ..xla_bridge.mpi_xla_bridge_gpu import build_scatter_descriptor
+    from ..xla_bridge.mpi_xla_bridge_xpu import build_scatter_descriptor
 
     comm = unpack_hashable(comm)
 


### PR DESCRIPTION
This PR extends mpi4jax scatter implementation to have XPU support

UT passrate with this PR:
====== 27 failed, 76 passed, 23 skipped, 2 warnings in 105.92s (0:01:45) =======
