### PR TITLE
JAdded XPU support for send,recv, and sendrecv ops

### DIFF
--- a/mpi4jax/_src/collective_ops/recv.py
+++ b/mpi4jax/_src/collective_ops/recv.py
@@ -143,8 +143,53 @@ def mpi_recv_xla_encode_cpu(ctx, x, token, source, tag, comm, status):
 
 @translation_rule_xpu
 def mpi_recv_xla_encode_xpu(ctx, x, token, source, tag, comm, status):
-    print("XPU RECV not implemented!")
-    exit(-1)
+    from ..xla_bridge.mpi_xla_bridge import MPI_STATUS_IGNORE_ADDR
+    from ..xla_bridge.mpi_xla_bridge_xpu import build_recv_descriptor
+
+    comm = unpack_hashable(comm)
+    status = unpack_hashable(status)
+
+    x_aval, *_ = ctx.avals_in
+    x_nptype = x_aval.dtype
+
+    x_type = ir.RankedTensorType(x.type)
+    dtype = x_type.element_type
+    dims = x_type.shape
+
+    # compute total number of elements in array
+    nitems = _np.prod(dims, dtype=int)
+    dtype_handle = to_dtype_handle(x_nptype)
+
+    out_types = [
+        ir.RankedTensorType.get(dims, dtype),
+        *token_type(),
+    ]
+
+    if status is None:
+        status_ptr = _np.uintp(MPI_STATUS_IGNORE_ADDR)
+    else:
+        status_ptr = to_mpi_ptr(status)
+
+    operands = (token,)
+
+    descriptor = build_recv_descriptor(
+        nitems,
+        source,
+        tag,
+        to_mpi_handle(comm),
+        dtype_handle,
+        status_ptr,
+    )
+
+    return custom_call(
+        b"mpi_recv",
+        result_types=out_types,
+        operands=operands,
+        operand_layouts=get_default_layouts(operands),
+        result_layouts=get_default_layouts(out_types),
+        has_side_effect=True,
+        backend_config=descriptor,
+    ).results
 
 @translation_rule_gpu
 def mpi_recv_xla_encode_gpu(ctx, x, token, source, tag, comm, status):

--- a/mpi4jax/_src/collective_ops/send.py
+++ b/mpi4jax/_src/collective_ops/send.py
@@ -108,8 +108,44 @@ def mpi_send_xla_encode_cpu(ctx, x, token, dest, tag, comm):
 
 @translation_rule_xpu
 def mpi_send_xla_encode_xpu(ctx, x, token, dest, tag, comm):
-    print("XPU SEND not implemented!")
-    exit(-1)
+    from ..xla_bridge.mpi_xla_bridge_xpu import build_send_descriptor
+
+    comm = unpack_hashable(comm)
+
+    x_aval, *_ = ctx.avals_in
+    x_nptype = x_aval.dtype
+
+    x_type = ir.RankedTensorType(x.type)
+    dims = x_type.shape
+
+    # compute total number of elements in array
+    nitems = _np.prod(dims, dtype=int)
+    dtype_handle = to_dtype_handle(x_nptype)
+
+    out_types = token_type()
+
+    operands = (
+        x,
+        token,
+    )
+
+    descriptor = build_send_descriptor(
+        nitems,
+        dest,
+        tag,
+        to_mpi_handle(comm),
+        dtype_handle,
+    )
+
+    return custom_call(
+        b"mpi_send",
+        result_types=out_types,
+        operands=operands,
+        operand_layouts=get_default_layouts(operands),
+        result_layouts=get_default_layouts(out_types),
+        has_side_effect=True,
+        backend_config=descriptor,
+    ).results
 
 @translation_rule_gpu
 def mpi_send_xla_encode_gpu(ctx, x, token, dest, tag, comm):

--- a/mpi4jax/_src/collective_ops/sendrecv.py
+++ b/mpi4jax/_src/collective_ops/sendrecv.py
@@ -212,8 +212,74 @@ def mpi_sendrecv_xla_encode_cpu(
 @translation_rule_xpu
 def mpi_sendrecv_xla_encode_xpu(ctx, sendbuf, recvbuf, token, source, dest, sendtag, recvtag, comm, status, _must_transpose=False,
 ):
-    print("XPU SENDRECV not implemented!")
-    exit(-1)
+    if _must_transpose:
+        raise RuntimeError(
+            "sendrecv cannot be used with forward-mode (vjp) autodiff, because "
+            "the gradient might be located on a different mpi rank than the "
+            "desired one. Use reverse-mode (jvp) differentiation instead."
+        )
+
+    from ..xla_bridge.mpi_xla_bridge import MPI_STATUS_IGNORE_ADDR
+    from ..xla_bridge.mpi_xla_bridge_xpu import build_sendrecv_descriptor
+
+    comm = unpack_hashable(comm)
+    status = unpack_hashable(status)
+
+    send_aval, recv_aval, *_ = ctx.avals_in
+    send_nptype = send_aval.dtype
+    recv_nptype = recv_aval.dtype
+
+    send_type = ir.RankedTensorType(sendbuf.type)
+    send_dims = send_type.shape
+
+    recv_type = ir.RankedTensorType(recvbuf.type)
+    recv_dtype = recv_type.element_type
+    recv_dims = recv_type.shape
+
+    # compute total number of elements in arrays
+    send_nitems = _np.prod(send_dims, dtype=int)
+    send_dtype_handle = to_dtype_handle(send_nptype)
+
+    recv_nitems = _np.prod(recv_dims, dtype=int)
+    recv_dtype_handle = to_dtype_handle(recv_nptype)
+
+    out_types = [
+        ir.RankedTensorType.get(recv_dims, recv_dtype),
+        *token_type(),
+    ]
+
+    if status is None:
+        status_ptr = _np.uintp(MPI_STATUS_IGNORE_ADDR)
+    else:
+        status_ptr = to_mpi_ptr(status)
+
+    operands = (
+        sendbuf,
+        token,
+    )
+
+    descriptor = build_sendrecv_descriptor(
+        send_nitems,
+        dest,
+        sendtag,
+        send_dtype_handle,
+        recv_nitems,
+        source,
+        recvtag,
+        recv_dtype_handle,
+        to_mpi_handle(comm),
+        status_ptr,
+    )
+
+    return custom_call(
+        b"mpi_sendrecv",
+        result_types=out_types,
+        operands=operands,
+        operand_layouts=get_default_layouts(operands),
+        result_layouts=get_default_layouts(out_types),
+        has_side_effect=True,
+        backend_config=descriptor,
+    ).results
 
 @translation_rule_gpu
 def mpi_sendrecv_xla_encode_gpu(

--- a/mpi4jax/_src/xla_bridge/mpi_xla_bridge_xpu.pyx
+++ b/mpi4jax/_src/xla_bridge/mpi_xla_bridge_xpu.pyx
@@ -834,7 +834,7 @@ cdef void mpi_send_xpu(void* stream, void** buffers,
         sendbuf = checked_malloc(count, comm)
 
         with gil:
-            checked_sycl_memcpy(xqueue, in_buf, data , count, comm)
+            checked_sycl_memcpy(xqueue, sendbuf, data , count, comm)
 
     mpi_xla_bridge.mpi_send(sendbuf, nitems, dtype, dest, tag, comm)
 


### PR DESCRIPTION
This PR is adding XPU support in send,recv and sendrecv operators of mpi4jax

**unit tests passrate with this PR:**
====== 25 failed, 78 passed, 23 skipped, 2 warnings in 127.71s (0:02:07) =======
