### PR TITLE
- XPU support added to alltoall op

### DIFF
--- a/mpi4jax/_src/collective_ops/alltoall.py
+++ b/mpi4jax/_src/collective_ops/alltoall.py
@@ -130,8 +130,53 @@ def mpi_alltoall_xla_encode_cpu(ctx, x, token, comm):
 
 @translation_rule_xpu
 def mpi_alltoall_xla_encode_xpu(ctx, x, token, comm):
-    print("XPU ALLTOALL not implemented!")
-    exit(-1)
+    from ..xla_bridge.mpi_xla_bridge_xpu import build_alltoall_descriptor
+
+    comm = unpack_hashable(comm)
+
+    x_aval, *_ = ctx.avals_in
+    x_nptype = x_aval.dtype
+
+    x_type = ir.RankedTensorType(x.type)
+    dtype = x_type.element_type
+    dims = x_type.shape
+
+    # compute total number of elements in array
+    size = comm.Get_size()
+    assert dims[0] == size
+    nitems_per_proc = _np.prod(dims[1:], dtype=int)
+    dtype_handle = to_dtype_handle(x_nptype)
+
+    out_types = [
+        ir.RankedTensorType.get(dims, dtype),
+        *token_type(),
+    ]
+
+    operands = (
+        x,
+        token,
+    )
+
+    descriptor = build_alltoall_descriptor(
+        nitems_per_proc,
+        dtype_handle,
+        # we only support matching input and output arrays
+        nitems_per_proc,
+        dtype_handle,
+        #
+        to_mpi_handle(comm),
+    )
+
+    return custom_call(
+        b"mpi_alltoall",
+        result_types=out_types,
+        operands=operands,
+        # force c order because first axis is special
+        operand_layouts=get_default_layouts(operands, order="c"),
+        result_layouts=get_default_layouts(out_types, order="c"),
+        has_side_effect=True,
+        backend_config=descriptor,
+    ).results
 
 @translation_rule_gpu
 def mpi_alltoall_xla_encode_gpu(ctx, x, token, comm):

--- a/mpi4jax/_src/xla_bridge/mpi_xla_bridge_xpu.pyx
+++ b/mpi4jax/_src/xla_bridge/mpi_xla_bridge_xpu.pyx
@@ -273,8 +273,9 @@ cdef void mpi_alltoall_xpu(void* stream, void** buffers,
     cdef MPI_Datatype recvtype = desc.recvtype
     cdef MPI_Comm comm = desc.comm
 
-# TODO: uncomment
-#    checked_cuda_stream_synchronize(stream, comm)
+    cdef queue* xqueue = <queue*>stream
+    with gil:
+        checked_sycl_queue_wait(xqueue, comm) 
 
     if COPY_TO_HOST:
         # copy memory to host
@@ -295,8 +296,8 @@ cdef void mpi_alltoall_xpu(void* stream, void** buffers,
         recvbytes = recvtype_size * recvcount * comm_size
         out_buf = checked_malloc(recvbytes, comm)
 
-# TODO: uncomment
-#        checked_cuda_memcpy(in_buf, data, sendbytes, cudaMemcpyDeviceToHost, comm)
+        with gil:
+            checked_sycl_memcpy(xqueue, in_buf, data , sendbytes, comm)
 
     mpi_xla_bridge.mpi_alltoall(
         in_buf, sendcount, sendtype, out_buf, recvcount, recvtype, comm
@@ -304,8 +305,8 @@ cdef void mpi_alltoall_xpu(void* stream, void** buffers,
 
     if COPY_TO_HOST:
         # copy back to device
-# TODO: uncomment
-#        checked_cuda_memcpy(out_data, out_buf, recvbytes, cudaMemcpyHostToDevice, comm)
+        with gil:
+            checked_sycl_memcpy(xqueue, out_data, out_buf , recvbytes, comm)
         free(in_buf)
         free(out_buf)
 


### PR DESCRIPTION
This PR is adding XPU support to alltoall mpi4jax op

Unit tests pass rate with this PR: 
============ 22 failed, 81 passed, 23 skipped, 2 warnings in 51.74s ============
