### PR TITLE
Extended notoken path with XPU support

### DIFF
--- a/mpi4jax/experimental/notoken/collective_ops/allgather.py
+++ b/mpi4jax/experimental/notoken/collective_ops/allgather.py
@@ -247,4 +247,4 @@ mpi_allgather_p.def_effectful_abstract_eval(mpi_allgather_abstract_eval)
 
 mlir.register_lowering(mpi_allgather_p, mpi_allgather_xla_encode_cpu, platform="cpu")
 mlir.register_lowering(mpi_allgather_p, mpi_allgather_xla_encode_gpu, platform="cuda")
-mlir.register_lowering(mpi_allgather_p, mpi_allgather_xla_encode_xpu, platform="sycl")
+mlir.register_lowering(mpi_allgather_p, mpi_allgather_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/experimental/notoken/collective_ops/allgather.py
+++ b/mpi4jax/experimental/notoken/collective_ops/allgather.py
@@ -18,7 +18,11 @@ from mpi4jax._src.utils import (
     ordered_effect,
 )
 from mpi4jax._src.jax_compat import custom_call, token_type, ShapedArray
-from mpi4jax._src.decorators import translation_rule_cpu, translation_rule_gpu
+from mpi4jax._src.decorators import (
+    translation_rule_cpu,
+    translation_rule_gpu,
+    translation_rule_xpu,
+)
 from mpi4jax._src.validation import enforce_types
 from mpi4jax._src.comm import get_default_comm
 
@@ -116,6 +120,63 @@ def mpi_allgather_xla_encode_cpu(ctx, sendbuf, comm):
     return results
 
 
+@translation_rule_xpu
+def mpi_allgather_xla_encode_xpu(ctx, sendbuf, comm):
+    from mpi4jax._src.xla_bridge.mpi_xla_bridge_xpu import build_allgather_descriptor
+
+    comm = unpack_hashable(comm)
+
+    sendbuf_aval, *_ = ctx.avals_in
+    send_nptype = sendbuf_aval.dtype
+
+    send_type = ir.RankedTensorType(sendbuf.type)
+    send_dtype = send_type.element_type
+    send_dims = send_type.shape
+
+    # compute total number of elements in send array
+    send_nitems = _np.prod(send_dims, dtype=int)
+    send_dtype_handle = to_dtype_handle(send_nptype)
+
+    size = comm.Get_size()
+    out_shape = (size, *send_dims)
+
+    out_types = [
+        ir.RankedTensorType.get(out_shape, send_dtype),
+        *token_type(),
+    ]
+
+    descriptor = build_allgather_descriptor(
+        send_nitems,
+        send_dtype_handle,
+        # we only support matching input and output arrays
+        send_nitems,
+        send_dtype_handle,
+        #
+        to_mpi_handle(comm),
+    )
+
+    token = ctx.tokens_in.get(ordered_effect)[0]
+
+    operands = (sendbuf, token)
+
+    result_obj = custom_call(
+        b"mpi_allgather",
+        result_types=out_types,
+        operands=operands,
+        # layout matters here, because the first axis is special
+        operand_layouts=get_default_layouts(operands, order="c"),
+        result_layouts=get_default_layouts(out_types, order="c"),
+        backend_config=descriptor,
+        has_side_effect=True,
+    )
+
+    results = list(result_obj.results)
+    token = results.pop(-1)
+    ctx.set_tokens_out(mlir.TokenSet({ordered_effect: (token,)}))
+
+    return results
+
+
 @translation_rule_gpu
 def mpi_allgather_xla_encode_gpu(ctx, sendbuf, comm):
     from mpi4jax._src.xla_bridge.mpi_xla_bridge_gpu import build_allgather_descriptor
@@ -186,3 +247,4 @@ mpi_allgather_p.def_effectful_abstract_eval(mpi_allgather_abstract_eval)
 
 mlir.register_lowering(mpi_allgather_p, mpi_allgather_xla_encode_cpu, platform="cpu")
 mlir.register_lowering(mpi_allgather_p, mpi_allgather_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_allgather_p, mpi_allgather_xla_encode_xpu, platform="sycl")

--- a/mpi4jax/experimental/notoken/collective_ops/allreduce.py
+++ b/mpi4jax/experimental/notoken/collective_ops/allreduce.py
@@ -294,4 +294,4 @@ ad.primitive_transposes[mpi_allreduce_p] = mpi_allreduce_transpose_rule
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_allreduce_p, mpi_allreduce_xla_encode_cpu, platform="cpu")
 mlir.register_lowering(mpi_allreduce_p, mpi_allreduce_xla_encode_gpu, platform="cuda")
-mlir.register_lowering(mpi_allreduce_p, mpi_allreduce_xla_encode_xpu, platform="sycl")
+mlir.register_lowering(mpi_allreduce_p, mpi_allreduce_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/experimental/notoken/collective_ops/allreduce.py
+++ b/mpi4jax/experimental/notoken/collective_ops/allreduce.py
@@ -20,7 +20,11 @@ from mpi4jax._src.utils import (
     ordered_effect,
 )
 from mpi4jax._src.jax_compat import custom_call, token_type, ShapedArray
-from mpi4jax._src.decorators import translation_rule_cpu, translation_rule_gpu
+from mpi4jax._src.decorators import (
+    translation_rule_cpu,
+    translation_rule_gpu,
+    translation_rule_xpu,
+)
 from mpi4jax._src.validation import enforce_types
 from mpi4jax._src.comm import get_default_comm
 
@@ -109,6 +113,65 @@ def mpi_allreduce_xla_encode_cpu(ctx, x, token, op, comm, transpose):
         operand_layouts=get_default_layouts(operands),
         result_layouts=get_default_layouts(out_types),
         has_side_effect=True,
+    )
+
+    results = list(result_obj.results)
+    token = results.pop(-1)
+    ctx.set_tokens_out(mlir.TokenSet({ordered_effect: (token,)}))
+
+    return results
+
+
+@translation_rule_xpu
+def mpi_allreduce_xla_encode_xpu(ctx, x, token, op, comm, transpose):
+    from mpi4jax._src.xla_bridge.mpi_xla_bridge_xpu import build_allreduce_descriptor
+
+    del token  # unused
+
+    op = unpack_hashable(op)
+    comm = unpack_hashable(comm)
+
+    if transpose:
+        assert op == _MPI.SUM
+        return [x]
+
+    x_aval, *_ = ctx.avals_in
+    x_nptype = x_aval.dtype
+
+    x_type = ir.RankedTensorType(x.type)
+    dtype = x_type.element_type
+    dims = x_type.shape
+
+    # compute total number of elements in array
+    nitems = _np.prod(dims, dtype=int)
+
+    out_types = [
+        ir.RankedTensorType.get(dims, dtype),
+        *token_type(),
+    ]
+
+    token = ctx.tokens_in.get(ordered_effect)[0]
+
+    operands = (
+        x,
+        token,
+    )
+
+    descriptor = build_allreduce_descriptor(
+        _np.intc(nitems),
+        to_mpi_handle(op),
+        to_mpi_handle(comm),
+        to_dtype_handle(x_nptype),
+    )
+
+    result_obj = custom_call(
+        b"mpi_allreduce",
+        result_types=out_types,
+        operands=operands,
+        operand_layouts=get_default_layouts(operands),
+        result_layouts=get_default_layouts(out_types),
+        has_side_effect=True,
+        backend_config=descriptor,
     )
 
     results = list(result_obj.results)
@@ -231,3 +294,4 @@ ad.primitive_transposes[mpi_allreduce_p] = mpi_allreduce_transpose_rule
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_allreduce_p, mpi_allreduce_xla_encode_cpu, platform="cpu")
 mlir.register_lowering(mpi_allreduce_p, mpi_allreduce_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_allreduce_p, mpi_allreduce_xla_encode_xpu, platform="sycl")

--- a/mpi4jax/experimental/notoken/collective_ops/alltoall.py
+++ b/mpi4jax/experimental/notoken/collective_ops/alltoall.py
@@ -18,7 +18,11 @@ from mpi4jax._src.utils import (
     ordered_effect,
 )
 from mpi4jax._src.jax_compat import custom_call, token_type, ShapedArray
-from mpi4jax._src.decorators import translation_rule_cpu, translation_rule_gpu
+from mpi4jax._src.decorators import (
+    translation_rule_cpu,
+    translation_rule_gpu,
+    translation_rule_xpu,
+)
 from mpi4jax._src.validation import enforce_types
 from mpi4jax._src.comm import get_default_comm
 
@@ -117,6 +121,64 @@ def mpi_alltoall_xla_encode_cpu(ctx, x, comm):
     return results
 
 
+@translation_rule_xpu
+def mpi_alltoall_xla_encode_xpu(ctx, x, comm):
+    from mpi4jax._src.xla_bridge.mpi_xla_bridge_xpu import build_alltoall_descriptor
+
+    comm = unpack_hashable(comm)
+
+    x_aval, *_ = ctx.avals_in
+    x_nptype = x_aval.dtype
+
+    x_type = ir.RankedTensorType(x.type)
+    dtype = x_type.element_type
+    dims = x_type.shape
+
+    # compute total number of elements in array
+    size = comm.Get_size()
+    assert dims[0] == size
+    nitems_per_proc = _np.prod(dims[1:], dtype=int)
+    dtype_handle = to_dtype_handle(x_nptype)
+
+    out_types = [
+        ir.RankedTensorType.get(dims, dtype),
+        *token_type(),
+    ]
+
+    token = ctx.tokens_in.get(ordered_effect)[0]
+
+    operands = (
+        x,
+        token,
+    )
+
+    descriptor = build_alltoall_descriptor(
+        nitems_per_proc,
+        dtype_handle,
+        # we only support matching input and output arrays
+        nitems_per_proc,
+        dtype_handle,
+        #
+        to_mpi_handle(comm),
+    )
+
+    result_obj = custom_call(
+        b"mpi_alltoall",
+        result_types=out_types,
+        operands=operands,
+        # force c order because first axis is special
+        operand_layouts=get_default_layouts(operands, order="c"),
+        result_layouts=get_default_layouts(out_types, order="c"),
+        has_side_effect=True,
+        backend_config=descriptor,
+    )
+
+    results = list(result_obj.results)
+    token = results.pop(-1)
+    ctx.set_tokens_out(mlir.TokenSet({ordered_effect: (token,)}))
+    return results
+
+
 @translation_rule_gpu
 def mpi_alltoall_xla_encode_gpu(ctx, x, comm):
     from mpi4jax._src.xla_bridge.mpi_xla_bridge_gpu import build_alltoall_descriptor
@@ -186,3 +248,4 @@ mpi_alltoall_p.def_effectful_abstract_eval(mpi_alltoall_abstract_eval)
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_alltoall_p, mpi_alltoall_xla_encode_cpu, platform="cpu")
 mlir.register_lowering(mpi_alltoall_p, mpi_alltoall_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_alltoall_p, mpi_alltoall_xla_encode_xpu, platform="sycl")

--- a/mpi4jax/experimental/notoken/collective_ops/alltoall.py
+++ b/mpi4jax/experimental/notoken/collective_ops/alltoall.py
@@ -248,4 +248,4 @@ mpi_alltoall_p.def_effectful_abstract_eval(mpi_alltoall_abstract_eval)
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_alltoall_p, mpi_alltoall_xla_encode_cpu, platform="cpu")
 mlir.register_lowering(mpi_alltoall_p, mpi_alltoall_xla_encode_gpu, platform="cuda")
-mlir.register_lowering(mpi_alltoall_p, mpi_alltoall_xla_encode_xpu, platform="sycl")
+mlir.register_lowering(mpi_alltoall_p, mpi_alltoall_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/experimental/notoken/collective_ops/barrier.py
+++ b/mpi4jax/experimental/notoken/collective_ops/barrier.py
@@ -161,4 +161,4 @@ batching.primitive_batchers[mpi_barrier_p] = mpi_barrier_batch_eval
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_barrier_p, mpi_barrier_xla_encode_cpu, platform="cpu")
 mlir.register_lowering(mpi_barrier_p, mpi_barrier_xla_encode_gpu, platform="cuda")
-mlir.register_lowering(mpi_barrier_p, mpi_barrier_xla_encode_xpu, platform="sycl")
+mlir.register_lowering(mpi_barrier_p, mpi_barrier_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/experimental/notoken/collective_ops/barrier.py
+++ b/mpi4jax/experimental/notoken/collective_ops/barrier.py
@@ -15,7 +15,11 @@ from mpi4jax._src.utils import (
     ordered_effect,
 )
 from mpi4jax._src.jax_compat import custom_call, token_type
-from mpi4jax._src.decorators import translation_rule_cpu, translation_rule_gpu
+from mpi4jax._src.decorators import (
+    translation_rule_cpu,
+    translation_rule_gpu,
+    translation_rule_xpu,
+)
 from mpi4jax._src.validation import enforce_types
 from mpi4jax._src.comm import get_default_comm
 
@@ -76,6 +80,37 @@ def mpi_barrier_xla_encode_cpu(ctx, comm):
     return results
 
 
+@translation_rule_xpu
+def mpi_barrier_xla_encode_xpu(ctx, comm):
+    from mpi4jax._src.xla_bridge.mpi_xla_bridge_xpu import build_barrier_descriptor
+
+    comm = unpack_hashable(comm)
+
+    out_types = token_type()
+
+    token = ctx.tokens_in.get(ordered_effect)[0]
+
+    operands = (token,)
+
+    descriptor = build_barrier_descriptor(to_mpi_handle(comm))
+
+    result_obj = custom_call(
+        b"mpi_barrier",
+        result_types=out_types,
+        operands=operands,
+        operand_layouts=get_default_layouts(operands),
+        result_layouts=get_default_layouts(out_types),
+        has_side_effect=True,
+        backend_config=descriptor,
+    )
+
+    results = list(result_obj.results)
+    token = results.pop(-1)
+    ctx.set_tokens_out(mlir.TokenSet({ordered_effect: (token,)}))
+
+    return results
+
+
 @translation_rule_gpu
 def mpi_barrier_xla_encode_gpu(ctx, comm):
     from mpi4jax._src.xla_bridge.mpi_xla_bridge_gpu import build_barrier_descriptor
@@ -126,3 +161,4 @@ batching.primitive_batchers[mpi_barrier_p] = mpi_barrier_batch_eval
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_barrier_p, mpi_barrier_xla_encode_cpu, platform="cpu")
 mlir.register_lowering(mpi_barrier_p, mpi_barrier_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_barrier_p, mpi_barrier_xla_encode_xpu, platform="sycl")

--- a/mpi4jax/experimental/notoken/collective_ops/bcast.py
+++ b/mpi4jax/experimental/notoken/collective_ops/bcast.py
@@ -18,7 +18,11 @@ from mpi4jax._src.utils import (
     ordered_effect,
 )
 from mpi4jax._src.jax_compat import custom_call, token_type, ShapedArray
-from mpi4jax._src.decorators import translation_rule_cpu, translation_rule_gpu
+from mpi4jax._src.decorators import (
+    translation_rule_cpu,
+    translation_rule_gpu,
+    translation_rule_xpu,
+)
 from mpi4jax._src.validation import enforce_types
 from mpi4jax._src.comm import get_default_comm
 
@@ -118,6 +122,64 @@ def mpi_bcast_xla_encode_cpu(ctx, x, root, comm):
     return results
 
 
+@translation_rule_xpu
+def mpi_bcast_xla_encode_xpu(ctx, x, root, comm):
+    from mpi4jax._src.xla_bridge.mpi_xla_bridge_gpu import build_bcast_descriptor
+
+    comm = unpack_hashable(comm)
+
+    x_aval, *_ = ctx.avals_in
+    x_nptype = x_aval.dtype
+
+    x_type = ir.RankedTensorType(x.type)
+    dtype = x_type.element_type
+    dims = x_type.shape
+
+    # compute total number of elements in array
+    nitems = _np.prod(dims, dtype=int)
+    dtype_handle = to_dtype_handle(x_nptype)
+
+    # output is not used on root, so prevent memory allocation
+    rank = comm.Get_rank()
+    if rank == root:
+        dims = (0,)
+
+    out_types = [
+        ir.RankedTensorType.get(dims, dtype),
+        *token_type(),
+    ]
+
+    token = ctx.tokens_in.get(ordered_effect)[0]
+
+    operands = (
+        x,
+        token,
+    )
+
+    descriptor = build_bcast_descriptor(
+        nitems,
+        root,
+        to_mpi_handle(comm),
+        dtype_handle,
+    )
+
+    result_obj = custom_call(
+        b"mpi_bcast",
+        result_types=out_types,
+        operands=operands,
+        operand_layouts=get_default_layouts(operands),
+        result_layouts=get_default_layouts(out_types),
+        has_side_effect=True,
+        backend_config=descriptor,
+    )
+
+    results = list(result_obj.results)
+    token = results.pop(-1)
+    ctx.set_tokens_out(mlir.TokenSet({ordered_effect: (token,)}))
+
+    return results
+
+
 @translation_rule_gpu
 def mpi_bcast_xla_encode_gpu(ctx, x, root, comm):
     from mpi4jax._src.xla_bridge.mpi_xla_bridge_gpu import build_bcast_descriptor
@@ -195,3 +257,4 @@ mpi_bcast_p.def_effectful_abstract_eval(mpi_bcast_abstract_eval)
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_bcast_p, mpi_bcast_xla_encode_cpu, platform="cpu")
 mlir.register_lowering(mpi_bcast_p, mpi_bcast_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_bcast_p, mpi_bcast_xla_encode_xpu, platform="sycl")

--- a/mpi4jax/experimental/notoken/collective_ops/bcast.py
+++ b/mpi4jax/experimental/notoken/collective_ops/bcast.py
@@ -257,4 +257,4 @@ mpi_bcast_p.def_effectful_abstract_eval(mpi_bcast_abstract_eval)
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_bcast_p, mpi_bcast_xla_encode_cpu, platform="cpu")
 mlir.register_lowering(mpi_bcast_p, mpi_bcast_xla_encode_gpu, platform="cuda")
-mlir.register_lowering(mpi_bcast_p, mpi_bcast_xla_encode_xpu, platform="sycl")
+mlir.register_lowering(mpi_bcast_p, mpi_bcast_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/experimental/notoken/collective_ops/gather.py
+++ b/mpi4jax/experimental/notoken/collective_ops/gather.py
@@ -18,7 +18,11 @@ from mpi4jax._src.utils import (
     ordered_effect,
 )
 from mpi4jax._src.jax_compat import custom_call, token_type, ShapedArray
-from mpi4jax._src.decorators import translation_rule_cpu, translation_rule_gpu
+from mpi4jax._src.decorators import (
+    translation_rule_cpu,
+    translation_rule_gpu,
+    translation_rule_xpu,
+)
 from mpi4jax._src.validation import enforce_types
 from mpi4jax._src.comm import get_default_comm
 
@@ -140,6 +144,73 @@ def mpi_gather_xla_encode_cpu(ctx, x, root, comm):
     return results
 
 
+@translation_rule_xpu
+def mpi_gather_xla_encode_xpu(ctx, x, root, comm):
+    from mpi4jax._src.xla_bridge.mpi_xla_bridge_xpu import build_gather_descriptor
+
+    comm = unpack_hashable(comm)
+
+    x_aval, *_ = ctx.avals_in
+    x_nptype = x_aval.dtype
+
+    x_type = ir.RankedTensorType(x.type)
+    dtype = x_type.element_type
+    dims = x_type.shape
+
+    # compute total number of elements in array
+    nitems = _np.prod(dims, dtype=int)
+
+    dtype_handle = to_dtype_handle(x_nptype)
+
+    # output is only used on root, so prevent memory allocation
+    rank = comm.Get_rank()
+    size = comm.Get_size()
+    if rank == root:
+        out_shape = (size, *dims)
+    else:
+        out_shape = (0,)
+
+    out_types = [
+        ir.RankedTensorType.get(out_shape, dtype),
+        *token_type(),
+    ]
+
+    token = ctx.tokens_in.get(ordered_effect)[0]
+
+    operands = (
+        x,
+        token,
+    )
+
+    descriptor = build_gather_descriptor(
+        nitems,
+        dtype_handle,
+        # we only support matching input and output arrays
+        nitems,
+        dtype_handle,
+        #
+        root,
+        to_mpi_handle(comm),
+    )
+
+    result_obj = custom_call(
+        b"mpi_gather",
+        result_types=out_types,
+        operands=operands,
+        # enforce c order because the first axis is special
+        operand_layouts=get_default_layouts(operands, order="c"),
+        result_layouts=get_default_layouts(out_types, order="c"),
+        has_side_effect=True,
+        backend_config=descriptor,
+    )
+
+    results = list(result_obj.results)
+    token = results.pop(-1)
+    ctx.set_tokens_out(mlir.TokenSet({ordered_effect: (token,)}))
+
+    return results
+
+
 @translation_rule_gpu
 def mpi_gather_xla_encode_gpu(ctx, x, root, comm):
     from mpi4jax._src.xla_bridge.mpi_xla_bridge_gpu import build_gather_descriptor
@@ -227,3 +298,4 @@ mpi_gather_p.def_effectful_abstract_eval(mpi_gather_abstract_eval)
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_gather_p, mpi_gather_xla_encode_cpu, platform="cpu")
 mlir.register_lowering(mpi_gather_p, mpi_gather_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_gather_p, mpi_gather_xla_encode_xpu, platform="sycl")

--- a/mpi4jax/experimental/notoken/collective_ops/gather.py
+++ b/mpi4jax/experimental/notoken/collective_ops/gather.py
@@ -298,4 +298,4 @@ mpi_gather_p.def_effectful_abstract_eval(mpi_gather_abstract_eval)
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_gather_p, mpi_gather_xla_encode_cpu, platform="cpu")
 mlir.register_lowering(mpi_gather_p, mpi_gather_xla_encode_gpu, platform="cuda")
-mlir.register_lowering(mpi_gather_p, mpi_gather_xla_encode_xpu, platform="sycl")
+mlir.register_lowering(mpi_gather_p, mpi_gather_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/experimental/notoken/collective_ops/recv.py
+++ b/mpi4jax/experimental/notoken/collective_ops/recv.py
@@ -19,7 +19,11 @@ from mpi4jax._src.utils import (
     ordered_effect,
 )
 from mpi4jax._src.jax_compat import custom_call, token_type, ShapedArray
-from mpi4jax._src.decorators import translation_rule_cpu, translation_rule_gpu
+from mpi4jax._src.decorators import (
+    translation_rule_cpu,
+    translation_rule_gpu,
+    translation_rule_xpu,
+)
 from mpi4jax._src.validation import enforce_types
 from mpi4jax._src.comm import get_default_comm
 
@@ -130,6 +134,65 @@ def mpi_recv_xla_encode_cpu(ctx, x, source, tag, comm, status):
     return results
 
 
+@translation_rule_xpu
+def mpi_recv_xla_encode_xpu(ctx, x, source, tag, comm, status):
+    from mpi4jax._src.xla_bridge.mpi_xla_bridge import MPI_STATUS_IGNORE_ADDR
+    from mpi4jax._src.xla_bridge.mpi_xla_bridge_xpu import build_recv_descriptor
+
+    comm = unpack_hashable(comm)
+    status = unpack_hashable(status)
+
+    x_aval, *_ = ctx.avals_in
+    x_nptype = x_aval.dtype
+
+    x_type = ir.RankedTensorType(x.type)
+    dtype = x_type.element_type
+    dims = x_type.shape
+
+    # compute total number of elements in array
+    nitems = _np.prod(dims, dtype=int)
+    dtype_handle = to_dtype_handle(x_nptype)
+
+    out_types = [
+        ir.RankedTensorType.get(dims, dtype),
+        *token_type(),
+    ]
+
+    if status is None:
+        status_ptr = _np.uintp(MPI_STATUS_IGNORE_ADDR)
+    else:
+        status_ptr = to_mpi_ptr(status)
+
+    token = ctx.tokens_in.get(ordered_effect)[0]
+
+    operands = (token,)
+
+    descriptor = build_recv_descriptor(
+        nitems,
+        source,
+        tag,
+        to_mpi_handle(comm),
+        dtype_handle,
+        status_ptr,
+    )
+
+    result_obj = custom_call(
+        b"mpi_recv",
+        result_types=out_types,
+        operands=operands,
+        operand_layouts=get_default_layouts(operands),
+        result_layouts=get_default_layouts(out_types),
+        has_side_effect=True,
+        backend_config=descriptor,
+    )
+
+    results = list(result_obj.results)
+    token = results.pop(-1)
+    ctx.set_tokens_out(mlir.TokenSet({ordered_effect: (token,)}))
+
+    return results
+
+
 @translation_rule_gpu
 def mpi_recv_xla_encode_gpu(ctx, x, source, tag, comm, status):
     from mpi4jax._src.xla_bridge.mpi_xla_bridge import MPI_STATUS_IGNORE_ADDR
@@ -200,3 +263,4 @@ mpi_recv_p.def_effectful_abstract_eval(mpi_recv_abstract_eval)
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_recv_p, mpi_recv_xla_encode_cpu, platform="cpu")
 mlir.register_lowering(mpi_recv_p, mpi_recv_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_recv_p, mpi_recv_xla_encode_xpu, platform="sycl")

--- a/mpi4jax/experimental/notoken/collective_ops/recv.py
+++ b/mpi4jax/experimental/notoken/collective_ops/recv.py
@@ -263,4 +263,4 @@ mpi_recv_p.def_effectful_abstract_eval(mpi_recv_abstract_eval)
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_recv_p, mpi_recv_xla_encode_cpu, platform="cpu")
 mlir.register_lowering(mpi_recv_p, mpi_recv_xla_encode_gpu, platform="cuda")
-mlir.register_lowering(mpi_recv_p, mpi_recv_xla_encode_xpu, platform="sycl")
+mlir.register_lowering(mpi_recv_p, mpi_recv_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/experimental/notoken/collective_ops/reduce.py
+++ b/mpi4jax/experimental/notoken/collective_ops/reduce.py
@@ -268,4 +268,4 @@ mpi_reduce_p.def_effectful_abstract_eval(mpi_reduce_abstract_eval)
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_reduce_p, mpi_reduce_xla_encode_cpu, platform="cpu")
 mlir.register_lowering(mpi_reduce_p, mpi_reduce_xla_encode_gpu, platform="cuda")
-mlir.register_lowering(mpi_reduce_p, mpi_reduce_xla_encode_xpu, platform="sycl")
+mlir.register_lowering(mpi_reduce_p, mpi_reduce_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/experimental/notoken/collective_ops/reduce.py
+++ b/mpi4jax/experimental/notoken/collective_ops/reduce.py
@@ -18,7 +18,11 @@ from mpi4jax._src.utils import (
     ordered_effect,
 )
 from mpi4jax._src.jax_compat import custom_call, token_type, ShapedArray
-from mpi4jax._src.decorators import translation_rule_cpu, translation_rule_gpu
+from mpi4jax._src.decorators import (
+    translation_rule_cpu,
+    translation_rule_gpu,
+    translation_rule_xpu,
+)
 from mpi4jax._src.validation import enforce_types
 from mpi4jax._src.comm import get_default_comm
 
@@ -121,6 +125,68 @@ def mpi_reduce_xla_encode_cpu(ctx, x, op, root, comm):
     return results
 
 
+@translation_rule_xpu
+def mpi_reduce_xla_encode_xpu(ctx, x, op, root, comm):
+    from mpi4jax._src.xla_bridge.mpi_xla_bridge_xpu import build_reduce_descriptor
+
+    op = unpack_hashable(op)
+    comm = unpack_hashable(comm)
+
+    x_aval, *_ = ctx.avals_in
+    x_nptype = x_aval.dtype
+
+    x_type = ir.RankedTensorType(x.type)
+    dtype = x_type.element_type
+    dims = x_type.shape
+
+    # compute total number of elements in array
+    nitems = _np.prod(dims, dtype=int)
+
+    dtype_handle = to_dtype_handle(x_nptype)
+
+    # output is only used on root, so prevent memory allocation
+    rank = comm.Get_rank()
+
+    if rank != root:
+        dims = (0,)
+
+    out_types = [
+        ir.RankedTensorType.get(dims, dtype),
+        *token_type(),
+    ]
+
+    token = ctx.tokens_in.get(ordered_effect)[0]
+
+    operands = (
+        x,
+        token,
+    )
+
+    descriptor = build_reduce_descriptor(
+        nitems,
+        to_mpi_handle(op),
+        root,
+        to_mpi_handle(comm),
+        dtype_handle,
+    )
+
+    result_obj = custom_call(
+        b"mpi_reduce",
+        result_types=out_types,
+        operands=operands,
+        operand_layouts=get_default_layouts(operands),
+        result_layouts=get_default_layouts(out_types),
+        has_side_effect=True,
+        backend_config=descriptor,
+    )
+
+    results = list(result_obj.results)
+    token = results.pop(-1)
+    ctx.set_tokens_out(mlir.TokenSet({ordered_effect: (token,)}))
+
+    return results
+
+
 @translation_rule_gpu
 def mpi_reduce_xla_encode_gpu(ctx, x, op, root, comm):
     from mpi4jax._src.xla_bridge.mpi_xla_bridge_gpu import build_reduce_descriptor
@@ -182,6 +248,7 @@ def mpi_reduce_xla_encode_gpu(ctx, x, op, root, comm):
 
     return results
 
+
 # This function evaluates only the shapes during AST construction
 def mpi_reduce_abstract_eval(xs, op, root, comm):
     comm = unpack_hashable(comm)
@@ -201,3 +268,4 @@ mpi_reduce_p.def_effectful_abstract_eval(mpi_reduce_abstract_eval)
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_reduce_p, mpi_reduce_xla_encode_cpu, platform="cpu")
 mlir.register_lowering(mpi_reduce_p, mpi_reduce_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_reduce_p, mpi_reduce_xla_encode_xpu, platform="sycl")

--- a/mpi4jax/experimental/notoken/collective_ops/scan.py
+++ b/mpi4jax/experimental/notoken/collective_ops/scan.py
@@ -228,4 +228,4 @@ mpi_scan_p.def_effectful_abstract_eval(mpi_scan_abstract_eval)
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_scan_p, mpi_scan_xla_encode_cpu, platform="cpu")
 mlir.register_lowering(mpi_scan_p, mpi_scan_xla_encode_gpu, platform="cuda")
-mlir.register_lowering(mpi_scan_p, mpi_scan_xla_encode_xpu, platform="sycl")
+mlir.register_lowering(mpi_scan_p, mpi_scan_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/experimental/notoken/collective_ops/scan.py
+++ b/mpi4jax/experimental/notoken/collective_ops/scan.py
@@ -18,7 +18,11 @@ from mpi4jax._src.utils import (
     ordered_effect,
 )
 from mpi4jax._src.jax_compat import custom_call, token_type, ShapedArray
-from mpi4jax._src.decorators import translation_rule_cpu, translation_rule_gpu
+from mpi4jax._src.decorators import (
+    translation_rule_cpu,
+    translation_rule_gpu,
+    translation_rule_xpu,
+)
 from mpi4jax._src.validation import enforce_types
 from mpi4jax._src.comm import get_default_comm
 
@@ -103,6 +107,61 @@ def mpi_scan_xla_encode_cpu(ctx, x, op, comm):
     return results
 
 
+@translation_rule_xpu
+def mpi_scan_xla_encode_xpu(ctx, x, op, comm):
+    from mpi4jax._src.xla_bridge.mpi_xla_bridge_xpu import build_scan_descriptor
+
+    op = unpack_hashable(op)
+    comm = unpack_hashable(comm)
+
+    x_aval, *_ = ctx.avals_in
+    x_nptype = x_aval.dtype
+
+    x_type = ir.RankedTensorType(x.type)
+    dtype = x_type.element_type
+    dims = x_type.shape
+
+    # compute total number of elements in array
+    nitems = _np.prod(dims, dtype=int)
+
+    dtype_handle = to_dtype_handle(x_nptype)
+
+    out_types = [
+        ir.RankedTensorType.get(dims, dtype),
+        *token_type(),
+    ]
+
+    token = ctx.tokens_in.get(ordered_effect)[0]
+
+    operands = (
+        x,
+        token,
+    )
+
+    descriptor = build_scan_descriptor(
+        nitems,
+        to_mpi_handle(op),
+        to_mpi_handle(comm),
+        dtype_handle,
+    )
+
+    result_obj = custom_call(
+        b"mpi_scan",
+        result_types=out_types,
+        operands=operands,
+        operand_layouts=get_default_layouts(operands),
+        result_layouts=get_default_layouts(out_types),
+        has_side_effect=True,
+        backend_config=descriptor,
+    )
+
+    results = list(result_obj.results)
+    token = results.pop(-1)
+    ctx.set_tokens_out(mlir.TokenSet({ordered_effect: (token,)}))
+
+    return results
+
+
 @translation_rule_gpu
 def mpi_scan_xla_encode_gpu(ctx, x, op, comm):
     from mpi4jax._src.xla_bridge.mpi_xla_bridge_gpu import build_scan_descriptor
@@ -169,3 +228,4 @@ mpi_scan_p.def_effectful_abstract_eval(mpi_scan_abstract_eval)
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_scan_p, mpi_scan_xla_encode_cpu, platform="cpu")
 mlir.register_lowering(mpi_scan_p, mpi_scan_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_scan_p, mpi_scan_xla_encode_xpu, platform="sycl")

--- a/mpi4jax/experimental/notoken/collective_ops/scatter.py
+++ b/mpi4jax/experimental/notoken/collective_ops/scatter.py
@@ -281,4 +281,4 @@ mpi_scatter_p.def_effectful_abstract_eval(mpi_scatter_abstract_eval)
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_scatter_p, mpi_scatter_xla_encode_cpu, platform="cpu")
 mlir.register_lowering(mpi_scatter_p, mpi_scatter_xla_encode_gpu, platform="cuda")
-mlir.register_lowering(mpi_scatter_p, mpi_scatter_xla_encode_xpu, platform="sycl")
+mlir.register_lowering(mpi_scatter_p, mpi_scatter_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/experimental/notoken/collective_ops/scatter.py
+++ b/mpi4jax/experimental/notoken/collective_ops/scatter.py
@@ -18,7 +18,11 @@ from mpi4jax._src.utils import (
     ordered_effect,
 )
 from mpi4jax._src.jax_compat import custom_call, token_type, ShapedArray
-from mpi4jax._src.decorators import translation_rule_cpu, translation_rule_gpu
+from mpi4jax._src.decorators import (
+    translation_rule_cpu,
+    translation_rule_gpu,
+    translation_rule_xpu,
+)
 from mpi4jax._src.validation import enforce_types
 from mpi4jax._src.comm import get_default_comm
 
@@ -137,6 +141,67 @@ def mpi_scatter_xla_encode_cpu(ctx, x, root, comm):
     return results
 
 
+@translation_rule_xpu
+def mpi_scatter_xla_encode_xpu(ctx, x, root, comm):
+    from mpi4jax._src.xla_bridge.mpi_xla_bridge_xpu import build_scatter_descriptor
+
+    comm = unpack_hashable(comm)
+
+    x_aval, *_ = ctx.avals_in
+    x_nptype = x_aval.dtype
+
+    x_type = ir.RankedTensorType(x.type)
+    dtype = x_type.element_type
+    dims = x_type.shape
+
+    rank = comm.Get_rank()
+    if rank == root:
+        dims = dims[1:]
+
+    # compute total number of elements in array
+    nitems = _np.prod(dims, dtype=int)
+    dtype_handle = to_dtype_handle(x_nptype)
+
+    out_types = [
+        ir.RankedTensorType.get(dims, dtype),
+        *token_type(),
+    ]
+
+    token = ctx.tokens_in.get(ordered_effect)[0]
+
+    operands = (
+        x,
+        token,
+    )
+
+    descriptor = build_scatter_descriptor(
+        nitems,
+        dtype_handle,
+        # we only support matching input and output arrays
+        nitems,
+        dtype_handle,
+        #
+        root,
+        to_mpi_handle(comm),
+    )
+
+    result_obj = custom_call(
+        b"mpi_scatter",
+        result_types=out_types,
+        operands=operands,
+        operand_layouts=get_default_layouts(operands),
+        result_layouts=get_default_layouts(out_types),
+        has_side_effect=True,
+        backend_config=descriptor,
+    )
+
+    results = list(result_obj.results)
+    token = results.pop(-1)
+    ctx.set_tokens_out(mlir.TokenSet({ordered_effect: (token,)}))
+
+    return results
+
+
 @translation_rule_gpu
 def mpi_scatter_xla_encode_gpu(ctx, x, root, comm):
     from mpi4jax._src.xla_bridge.mpi_xla_bridge_gpu import build_scatter_descriptor
@@ -216,3 +281,4 @@ mpi_scatter_p.def_effectful_abstract_eval(mpi_scatter_abstract_eval)
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_scatter_p, mpi_scatter_xla_encode_cpu, platform="cpu")
 mlir.register_lowering(mpi_scatter_p, mpi_scatter_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_scatter_p, mpi_scatter_xla_encode_xpu, platform="sycl")

--- a/mpi4jax/experimental/notoken/collective_ops/send.py
+++ b/mpi4jax/experimental/notoken/collective_ops/send.py
@@ -18,7 +18,11 @@ from mpi4jax._src.utils import (
     ordered_effect,
 )
 from mpi4jax._src.jax_compat import custom_call, token_type
-from mpi4jax._src.decorators import translation_rule_cpu, translation_rule_gpu
+from mpi4jax._src.decorators import (
+    translation_rule_cpu,
+    translation_rule_gpu,
+    translation_rule_xpu,
+)
 from mpi4jax._src.validation import enforce_types
 from mpi4jax._src.comm import get_default_comm
 
@@ -103,6 +107,56 @@ def mpi_send_xla_encode_cpu(ctx, x, dest, tag, comm):
     return results
 
 
+@translation_rule_xpu
+def mpi_send_xla_encode_xpu(ctx, x, dest, tag, comm):
+    from mpi4jax._src.xla_bridge.mpi_xla_bridge_xpu import build_send_descriptor
+
+    comm = unpack_hashable(comm)
+
+    x_aval, *_ = ctx.avals_in
+    x_nptype = x_aval.dtype
+
+    x_type = ir.RankedTensorType(x.type)
+    dims = x_type.shape
+
+    # compute total number of elements in array
+    nitems = _np.prod(dims, dtype=int)
+    dtype_handle = to_dtype_handle(x_nptype)
+
+    out_types = token_type()
+
+    token = ctx.tokens_in.get(ordered_effect)[0]
+
+    operands = (
+        x,
+        token,
+    )
+
+    descriptor = build_send_descriptor(
+        nitems,
+        dest,
+        tag,
+        to_mpi_handle(comm),
+        dtype_handle,
+    )
+
+    result_obj = custom_call(
+        b"mpi_send",
+        result_types=out_types,
+        operands=operands,
+        operand_layouts=get_default_layouts(operands),
+        result_layouts=get_default_layouts(out_types),
+        has_side_effect=True,
+        backend_config=descriptor,
+    )
+
+    results = list(result_obj.results)
+    token = results.pop(-1)
+    ctx.set_tokens_out(mlir.TokenSet({ordered_effect: (token,)}))
+
+    return results
+
+
 @translation_rule_gpu
 def mpi_send_xla_encode_gpu(ctx, x, dest, tag, comm):
     from mpi4jax._src.xla_bridge.mpi_xla_bridge_gpu import build_send_descriptor
@@ -165,3 +219,4 @@ mpi_send_p.def_effectful_abstract_eval(mpi_send_abstract_eval)
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_send_p, mpi_send_xla_encode_cpu, platform="cpu")
 mlir.register_lowering(mpi_send_p, mpi_send_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_send_p, mpi_send_xla_encode_xpu, platform="sycl")

--- a/mpi4jax/experimental/notoken/collective_ops/send.py
+++ b/mpi4jax/experimental/notoken/collective_ops/send.py
@@ -219,4 +219,4 @@ mpi_send_p.def_effectful_abstract_eval(mpi_send_abstract_eval)
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_send_p, mpi_send_xla_encode_cpu, platform="cpu")
 mlir.register_lowering(mpi_send_p, mpi_send_xla_encode_gpu, platform="cuda")
-mlir.register_lowering(mpi_send_p, mpi_send_xla_encode_xpu, platform="sycl")
+mlir.register_lowering(mpi_send_p, mpi_send_xla_encode_xpu, platform="xpu")

--- a/mpi4jax/experimental/notoken/collective_ops/sendrecv.py
+++ b/mpi4jax/experimental/notoken/collective_ops/sendrecv.py
@@ -21,7 +21,11 @@ from mpi4jax._src.utils import (
     ordered_effect,
 )
 from mpi4jax._src.jax_compat import custom_call, token_type, ShapedArray
-from mpi4jax._src.decorators import translation_rule_cpu, translation_rule_gpu
+from mpi4jax._src.decorators import (
+    translation_rule_cpu,
+    translation_rule_gpu,
+    translation_rule_xpu,
+)
 from mpi4jax._src.validation import enforce_types
 from mpi4jax._src.comm import get_default_comm
 
@@ -183,6 +187,100 @@ def mpi_sendrecv_xla_encode_cpu(
         operand_layouts=get_default_layouts(operands),
         result_layouts=get_default_layouts(out_types),
         has_side_effect=True,
+    )
+
+    results = list(result_obj.results)
+    token = results.pop(-1)
+    ctx.set_tokens_out(mlir.TokenSet({ordered_effect: (token,)}))
+
+    return results
+
+
+@translation_rule_xpu
+def mpi_sendrecv_xla_encode_xpu(
+    ctx,
+    sendbuf,
+    recvbuf,
+    token,
+    source,
+    dest,
+    sendtag,
+    recvtag,
+    comm,
+    status,
+    _must_transpose=False,
+):
+    if _must_transpose:
+        raise RuntimeError(
+            "sendrecv cannot be used with forward-mode (vjp) autodiff, because "
+            "the gradient might be located on a different mpi rank than the "
+            "desired one. Use reverse-mode (jvp) differentiation instead."
+        )
+
+    from mpi4jax._src.xla_bridge.mpi_xla_bridge import MPI_STATUS_IGNORE_ADDR
+    from mpi4jax._src.xla_bridge.mpi_xla_bridge_xpu import build_sendrecv_descriptor
+
+    del token  # unused
+
+    comm = unpack_hashable(comm)
+    status = unpack_hashable(status)
+
+    send_aval, recv_aval, *_ = ctx.avals_in
+    send_nptype = send_aval.dtype
+    recv_nptype = recv_aval.dtype
+
+    send_type = ir.RankedTensorType(sendbuf.type)
+    send_dims = send_type.shape
+
+    recv_type = ir.RankedTensorType(recvbuf.type)
+    recv_dtype = recv_type.element_type
+    recv_dims = recv_type.shape
+
+    # compute total number of elements in arrays
+    send_nitems = _np.prod(send_dims, dtype=int)
+    send_dtype_handle = to_dtype_handle(send_nptype)
+
+    recv_nitems = _np.prod(recv_dims, dtype=int)
+    recv_dtype_handle = to_dtype_handle(recv_nptype)
+
+    out_types = [
+        ir.RankedTensorType.get(recv_dims, recv_dtype),
+        *token_type(),
+    ]
+
+    if status is None:
+        status_ptr = _np.uintp(MPI_STATUS_IGNORE_ADDR)
+    else:
+        status_ptr = to_mpi_ptr(status)
+
+    token = ctx.tokens_in.get(ordered_effect)[0]
+
+    operands = (
+        sendbuf,
+        token,
+    )
+
+    descriptor = build_sendrecv_descriptor(
+        send_nitems,
+        dest,
+        sendtag,
+        send_dtype_handle,
+        recv_nitems,
+        source,
+        recvtag,
+        recv_dtype_handle,
+        to_mpi_handle(comm),
+        status_ptr,
+    )
+
+    result_obj = custom_call(
+        b"mpi_sendrecv",
+        result_types=out_types,
+        operands=operands,
+        operand_layouts=get_default_layouts(operands),
+        result_layouts=get_default_layouts(out_types),
+        has_side_effect=True,
+        backend_config=descriptor,
     )
 
     results = list(result_obj.results)
@@ -408,3 +506,4 @@ ad.primitive_transposes[mpi_sendrecv_p] = mpi_sendrecv_transpose_rule
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_sendrecv_p, mpi_sendrecv_xla_encode_cpu, platform="cpu")
 mlir.register_lowering(mpi_sendrecv_p, mpi_sendrecv_xla_encode_gpu, platform="cuda")
+mlir.register_lowering(mpi_sendrecv_p, mpi_sendrecv_xla_encode_xpu, platform="sycl")

--- a/mpi4jax/experimental/notoken/collective_ops/sendrecv.py
+++ b/mpi4jax/experimental/notoken/collective_ops/sendrecv.py
@@ -506,4 +506,4 @@ ad.primitive_transposes[mpi_sendrecv_p] = mpi_sendrecv_transpose_rule
 # assign to the primitive the correct encoder
 mlir.register_lowering(mpi_sendrecv_p, mpi_sendrecv_xla_encode_cpu, platform="cpu")
 mlir.register_lowering(mpi_sendrecv_p, mpi_sendrecv_xla_encode_gpu, platform="cuda")
-mlir.register_lowering(mpi_sendrecv_p, mpi_sendrecv_xla_encode_xpu, platform="sycl")
+mlir.register_lowering(mpi_sendrecv_p, mpi_sendrecv_xla_encode_xpu, platform="xpu")


### PR DESCRIPTION
This PR is extending experimental notoken path with XPU support

unit tests pass rate with this PR:

##### pytest .
============ 2 failed, 101 passed, 23 skipped, 2 warnings in 48.83s ===========

##### mpirun -np 2 pytest 2
============= 3 failed, 123 passed, 2 warnings in 63.06s (0:01:03) =============
