### PR TITLE
Make sure OpenMPI C++ bindings is not used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 from setuptools.extension import Extension
 from setuptools.command.build_ext import build_ext
 
-#logging.basicConfig(level=logging.INFO)
+# logging.basicConfig(level=logging.INFO)
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -125,10 +125,12 @@ def get_cuda_path():
 
     return _cuda_path
 
+
 def get_sycl_path():
-    basekit = os.environ.get('ONEAPI_ROOT')
+    basekit = os.environ.get("ONEAPI_ROOT")
     logging.info("ONEAPI_ROOT={basekit}")
     return basekit
+
 
 def get_sycl_info():
     sycl_info = {"compile": [], "libdirs": [], "libs": []}
@@ -141,7 +143,7 @@ def get_sycl_info():
         "compiler/latest/linux/include/sycl",
         "compiler/latest/include/",
         "compiler/latest/include/sycl",
-            ]
+    ]
 
     for inc_suffix in include_suffixes:
         incdir = os.path.join(sycl_path, inc_suffix)
@@ -149,12 +151,12 @@ def get_sycl_info():
             sycl_info["compile"].append(incdir)
             logging.info("Adding include={incdir}")
 
-    libdir_suffixes = [ 
-           "compiler/latest/linux/lib/",
-           "compiler/latest/lib/",
-            ]
+    libdir_suffixes = [
+        "compiler/latest/linux/lib/",
+        "compiler/latest/lib/",
+    ]
     for libdir_suffix in libdir_suffixes:
-        lib_dir = os.path.join(sycl_path,libdir_suffix)
+        lib_dir = os.path.join(sycl_path, libdir_suffix)
         if os.path.isdir(lib_dir):
             sycl_info["libdirs"].append(lib_dir)
             logging.info("Adding lib dir={lib_dir}")
@@ -162,7 +164,9 @@ def get_sycl_info():
     sycl_info["libs"].append("sycl")
     return sycl_info
 
+
 sycl_info = get_sycl_info()
+
 
 def get_cuda_info():
     cuda_info = {"compile": [], "libdirs": [], "libs": []}
@@ -211,7 +215,6 @@ def get_extensions():
         for mod in ("mpi_xla_bridge", "mpi_xla_bridge_cpu")
     ]
 
-
     if sycl_info["compile"] and sycl_info["libdirs"]:
         extensions.append(
             Extension(
@@ -221,10 +224,14 @@ def get_extensions():
                 library_dirs=sycl_info["libdirs"],
                 libraries=sycl_info["libs"],
                 language="c++",
+                define_macros=[("OMPI_SKIP_MPICXX", "1")],
             )
         )
     else:
-        print_warning("SYCL (Intel Basekit) path not found. Did you call {you basekit dir}/setvars.sh? You can use env var ONEAPI_ROOT to point Basekit directory where sycl is", "(XPU extensions will not be built)")
+        print_warning(
+            "SYCL (Intel Basekit) path not found. Did you call {you basekit dir}/setvars.sh? You can use env var ONEAPI_ROOT to point Basekit directory where sycl is",
+            "(XPU extensions will not be built)",
+        )
 
     if cuda_info["compile"] and cuda_info["libdirs"]:
         extensions.append(


### PR DESCRIPTION
When building XPU extension we use C++ compiler and if MPI implementation (tested on OpenMPI) is having MPI C++ bindings then this MPI c++ is used. MPI C++ is deprecated and tend to cause some problems so changes hwere are passing a definition not to use OpenMPI C++ bindings to avoid problems that this C++ binding cause.