### PR TITLE
- Fix to sendrecv problem

### DIFF
--- a/mpi4jax/_src/collective_ops/sendrecv.py
+++ b/mpi4jax/_src/collective_ops/sendrecv.py
@@ -226,7 +226,7 @@ def mpi_sendrecv_xla_encode_device(
     recvtag,
     comm,
     status,
-    _must_transpose=False,
+    _must_transpose,
 ):
     if _must_transpose:
         raise RuntimeError(
@@ -325,7 +325,7 @@ def mpi_sendrecv_xla_encode_xpu(
         recvtag,
         comm,
         status,
-        _must_transpose=False,
+        _must_transpose,
     )
 
 
@@ -357,7 +357,7 @@ def mpi_sendrecv_xla_encode_gpu(
         recvtag,
         comm,
         status,
-        _must_transpose=False,
+        _must_transpose,
     )
 
 

--- a/mpi4jax/experimental/notoken/collective_ops/sendrecv.py
+++ b/mpi4jax/experimental/notoken/collective_ops/sendrecv.py
@@ -208,7 +208,7 @@ def mpi_sendrecv_xla_encode_device(
     recvtag,
     comm,
     status,
-    _must_transpose=False,
+    _must_transpose,
 ):
     if _must_transpose:
         raise RuntimeError(
@@ -317,7 +317,7 @@ def mpi_sendrecv_xla_encode_xpu(
         recvtag,
         comm,
         status,
-        _must_transpose=False,
+        _must_transpose,
     )
 
 
@@ -349,7 +349,7 @@ def mpi_sendrecv_xla_encode_gpu(
         recvtag,
         comm,
         status,
-        _must_transpose=False,
+        _must_transpose,
     )
 
 


### PR DESCRIPTION
Fix to test_sendrecv unit test. With thi change:

=========================== short test summary info ============================
FAILED tests/collective_ops/test_barrier.py::test_barrier - AssertionError: a...
======== 1 failed, 122 passed, 3 skipped, 1 warning in 63.08s (0:01:03) ========
(same result as CPU)