### PR TITLE
Remove redundant export

### DIFF
--- a/.github/workflows/build-xpu-ext.yml
+++ b/.github/workflows/build-xpu-ext.yml
@@ -46,6 +46,5 @@ jobs:
     - name: Build XPU extensions
       run: |
         source $HOME/basekit/setvars.sh
-        export ONEAPI_ROOT=$HOME/basekit
         python setup.py build_ext --inplace
         test -f mpi4jax/_src/xla_bridge/mpi_xla_bridge_xpu*.so


### PR DESCRIPTION
setvars.sh exports `ONEAPI_ROOT` so it is not needed to export it second time